### PR TITLE
Flexible implementation for /dev/sda1 or /dev/mmcblk0p1 partition numbers

### DIFF
--- a/flash_sd.sh
+++ b/flash_sd.sh
@@ -35,6 +35,7 @@ if [ $UID -ne 0 ]
     exit
 fi
 
+if [ -e $SDCARD"p1" ] 
 
 pt_info "Umounting $out, please wait..."
 umount ${SDCARD}* >/dev/null 2>&1
@@ -47,26 +48,34 @@ sync
 sudo partprobe ${SDCARD}
 sleep 2
 
+if [ -e ${SDCARD}"p1" ]; then
+    pt_info "Detected version of Linux where partition files are prefixed with p (${SDCARD}p1)"
+    $p = "p"
+else
+    pt_info "Detected version of linux where partition files are not prefixed with p (${SDCARD}1)"
+    $p = ""
+fi
+
 set -e
 
 pt_warn "Flashing $SDCARD...."
 dd if=./boot0.bin conv=notrunc bs=1k seek=8 of=${SDCARD}
 dd if=./ub-nanopi-a64.bin conv=notrunc bs=1k seek=19096 of=${SDCARD}
 
-pt_info "Decompressing rootfs to $SDCARD"2", please wait... (takes some time)"
+pt_info "Decompressing rootfs to ${SDCARD}${p}"2", please wait... (takes some time)"
 mkdir -p erootfs
 sudo partprobe ${SDCARD}
 sleep 4
-sudo mount $SDCARD"2" erootfs
+sudo mount ${SDCARD}${p}"2" erootfs
 tar -xvpzf rootfs_nanopia64_rc1.tar.gz -C ./erootfs --numeric-ow
 sync
 sudo umount erootfs
 rm -fR erootfs
 sync
-pt_info "Decompressing boot to $SDCARD"1", please wait..."
+pt_info "Decompressing boot to ${SDCARD}${p}"1", please wait..."
 set +e
 mkdir eboot
-sudo mount $SDCARD"1" eboot
+sudo mount -t vfat ${SDCARD}${p}"1" eboot
 tar -xvpzf boot_nanopia64_rc1.tar.gz -C ./eboot --no-same-owner
 sync
 sudo umount eboot

--- a/flash_sd.sh
+++ b/flash_sd.sh
@@ -35,8 +35,6 @@ if [ $UID -ne 0 ]
     exit
 fi
 
-if [ -e $SDCARD"p1" ] 
-
 pt_info "Umounting $out, please wait..."
 umount ${SDCARD}* >/dev/null 2>&1
 sleep 1

--- a/flash_sd.sh
+++ b/flash_sd.sh
@@ -48,10 +48,10 @@ sleep 2
 
 if [ -e ${SDCARD}"p1" ]; then
     pt_info "Detected version of Linux where partition files are prefixed with p (${SDCARD}p1)"
-    $p = "p"
+    addp="p"
 else
     pt_info "Detected version of linux where partition files are not prefixed with p (${SDCARD}1)"
-    $p = ""
+    addp=""
 fi
 
 set -e
@@ -60,20 +60,20 @@ pt_warn "Flashing $SDCARD...."
 dd if=./boot0.bin conv=notrunc bs=1k seek=8 of=${SDCARD}
 dd if=./ub-nanopi-a64.bin conv=notrunc bs=1k seek=19096 of=${SDCARD}
 
-pt_info "Decompressing rootfs to ${SDCARD}${p}"2", please wait... (takes some time)"
+pt_info "Decompressing rootfs to ${SDCARD}${addp}"2", please wait... (takes some time)"
 mkdir -p erootfs
 sudo partprobe ${SDCARD}
 sleep 4
-sudo mount ${SDCARD}${p}"2" erootfs
+sudo mount ${SDCARD}${addp}"2" erootfs
 tar -xvpzf rootfs_nanopia64_rc1.tar.gz -C ./erootfs --numeric-ow
 sync
 sudo umount erootfs
 rm -fR erootfs
 sync
-pt_info "Decompressing boot to ${SDCARD}${p}"1", please wait..."
+pt_info "Decompressing boot to ${SDCARD}${addp}"1", please wait..."
 set +e
 mkdir eboot
-sudo mount -t vfat ${SDCARD}${p}"1" eboot
+sudo mount -t vfat ${SDCARD}${addp}"1" eboot
 tar -xvpzf boot_nanopia64_rc1.tar.gz -C ./eboot --no-same-owner
 sync
 sudo umount eboot

--- a/format_sd.sh
+++ b/format_sd.sh
@@ -79,15 +79,23 @@ sync
 partprobe -s ${out}
 sync
 
+if [ -e ${out}"p1" ]; then
+    pt_info "Detected version of Linux where partition files are prefixed with p (${out}p1)"
+    $p = "p"
+else
+    pt_info "Detected version of linux where partition files are not prefixed with p (${out}1)"
+    $p = ""
+fi
+
 pt_warn "Formating $out ..."
 # Create boot file system (VFAT)
-dd if=/dev/zero bs=1M count=${boot_size} of=${out}1
-mkfs.vfat -n boot -I ${out}1
+dd if=/dev/zero bs=1M count=${boot_size} of=${out}${p}1
+mkfs.vfat -n boot -I ${out}${p}1
 
 # Create ext4 file system for rootfs
-mkfs.ext4 -F -b 4096 -E stride=2,stripe-width=1024 -L rootfs ${out}2
+mkfs.ext4 -F -b 4096 -E stride=2,stripe-width=1024 -L rootfs ${out}${p}2
 sync
-sudo tune2fs -O ^has_journal ${out}2
+sudo tune2fs -O ^has_journal ${out}${p}2
 sync
 
 pt_ok "Done - Geometry created and sd card '$out' formatted, now flash the image with ./flash_sd.sh"

--- a/format_sd.sh
+++ b/format_sd.sh
@@ -81,21 +81,21 @@ sync
 
 if [ -e ${out}"p1" ]; then
     pt_info "Detected version of Linux where partition files are prefixed with p (${out}p1)"
-    $p = "p"
+    addp="p"
 else
     pt_info "Detected version of linux where partition files are not prefixed with p (${out}1)"
-    $p = ""
+    addp=""
 fi
 
 pt_warn "Formating $out ..."
 # Create boot file system (VFAT)
-dd if=/dev/zero bs=1M count=${boot_size} of=${out}${p}1
-mkfs.vfat -n boot -I ${out}${p}1
+dd if=/dev/zero bs=1M count=${boot_size} of=${out}${addp}1
+mkfs.vfat -n boot -I ${out}${addp}1
 
 # Create ext4 file system for rootfs
-mkfs.ext4 -F -b 4096 -E stride=2,stripe-width=1024 -L rootfs ${out}${p}2
+mkfs.ext4 -F -b 4096 -E stride=2,stripe-width=1024 -L rootfs ${out}${addp}2
 sync
-sudo tune2fs -O ^has_journal ${out}${p}2
+sudo tune2fs -O ^has_journal ${out}${addp}2
 sync
 
 pt_ok "Done - Geometry created and sd card '$out' formatted, now flash the image with ./flash_sd.sh"


### PR DESCRIPTION
Hi,

I tested this on my Ubuntu machine only. Can you please test it on your system where the partition is accessible through /dev/sdc1 ?

Thanks!